### PR TITLE
Patch ch tool meson build script to respect install_prefix

### DIFF
--- a/pkgs/development/libraries/libvirt/0002-meson-patch-ch-install-prefix.patch
+++ b/pkgs/development/libraries/libvirt/0002-meson-patch-ch-install-prefix.patch
@@ -1,0 +1,14 @@
+diff --git a/src/ch/meson.build b/src/ch/meson.build
+index e34974d56c..4767763c2c 100644
+--- a/src/ch/meson.build
++++ b/src/ch/meson.build
+@@ -68,7 +68,7 @@ if conf.has('WITH_CH')
+   }
+ 
+   virt_install_dirs += [
+-    localstatedir / 'lib' / 'libvirt' / 'ch',
+-    runstatedir / 'libvirt' / 'ch',
++    install_prefix + localstatedir / 'lib' / 'libvirt' / 'ch',
++    install_prefix + runstatedir / 'libvirt' / 'ch',
+   ]
+ endif

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -50,6 +50,7 @@ in stdenv.mkDerivation rec {
 
   patches = [
     ./0001-meson-patch-in-an-install-prefix-for-building-on-nix.patch
+    ./0002-meson-patch-ch-install-prefix.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
This follows the discussion at NixOS/nixpkgs#130805. The patch in this MR fixes `PermissionError: [Errno 13] Permission denied: '/var'` issues during the build.